### PR TITLE
Fix bug when response_times is empty

### DIFF
--- a/files/exporter.py
+++ b/files/exporter.py
@@ -63,7 +63,7 @@ def format_prometheus(data):
             item.get('interval'),
             value,
         )
-        if item.get('status', 0) == 2:
+        if item.get('status', 0) == 2 and item.get('response_times'):
             result += 'uptimerobot_response_time{{name="{}",type="{}",url="{}"}} {}\n'.format(
                 item.get('friendly_name'),
                 item.get('type'),


### PR DESCRIPTION
Hello,

Recently UptimeRobot rolled out a change and if you monitor a 404 page you won't get any response_times:
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/2182934/132514459-f604cda2-6e53-460f-8f28-bb175ee16d91.png">

Therefore, the exporter was throwing this error:
<img width="661" alt="image" src="https://user-images.githubusercontent.com/2182934/132514769-6a112799-b1f2-474a-b832-1d8c7c0f7c2b.png">

This PR fixes it by appending `uptimerobot_response_time(...)` only to services that actually have response times. 